### PR TITLE
Docker compose: Run Jupyter by default and expose port

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -15,14 +15,7 @@ The recommended mode of working with the notebooks is to use the [VS Code Dev Co
 ## Without Visual Studio Code
 
 To work with the notebooks without VS Code:
-1. Choose an unused port on the host, say, 7139.
-2. `ssh` to the host with the port exposed: `ssh -L 7139:7139 <username>@vae.ist.berkeley.edu`
-3. Go to `KataGoVisualizer` and build the notebook Docker image: `docker build .
-   -f notebooks/Dockerfile -t humancompatibleai/katagovisualizer:notebook`
-4. Assuming `KataGoVisualizer` is located at `~/KataGoVisualizer`, run the
-   notebook inside the container: `docker run -v ~/KataGoVisualizer:/viz -v
-   /nas/ucb:/nas/ucb -p 7139:7139 -it
-   humancompatibleai/katagovisualizer:notebook sh -c "jupyter notebook --port
-   7139 --ip 0.0.0.0 --allow-root --notebook-dir /viz/notebooks/notebooks"`
-5. This should print out a URL like `http://127.0.0.1:7139/?token=<...>`.
-   Navigate to that URL on your local computer.
+1. Run `docker-compose -f notebooks/docker-compose.yml up`. This should print out a URL like `http://127.0.0.1:8888/?token=<...>`.
+2. Run `docker ps` to find the port that it bound to on the host, call it PORT
+3. `ssh` to the host to forward that port to port 8888 on your local machine: `ssh -L 8888:localhost:PORT`.
+4. Navigate to that URL output at step 1 on your local computer.

--- a/notebooks/docker-compose.yml
+++ b/notebooks/docker-compose.yml
@@ -22,8 +22,9 @@ services:
       - SYS_PTRACE  # to enable gdb debugging
     tty: true
     ports:
-      # Host will chose a random available port. To find the port allocated, run
-      # docker-compose -f notebooks/docker-compose.yml port notebooks 8888
+      # Host will bind a randomly chosen available port on localhost (127.0.0.1)
+      # to the container's port 8888 that Jupyter notebook listens on.
+      # To find the port allocated, run `docker ps`.
       - 127.0.0.1::8888
     working_dir: /KataGoVisualizer
     entrypoint: "jupyter-notebook --allow-root --ip=*"

--- a/notebooks/docker-compose.yml
+++ b/notebooks/docker-compose.yml
@@ -21,3 +21,9 @@ services:
     cap_add:
       - SYS_PTRACE  # to enable gdb debugging
     tty: true
+    ports:
+      # Host will chose a random available port. To find the port allocated, run
+      # docker-compose -f notebooks/docker-compose.yml port notebooks 8888
+      - 127.0.0.1::8888
+    working_dir: /KataGoVisualizer
+    entrypoint: "jupyter-notebook --allow-root --ip=*"


### PR DESCRIPTION
Quality of life improvement to `docker-compose.yml` to start Jupyter notebook automatically (no need to `docker exec` and run it manually), and expose the port (no need to mess around with extra port forwarding or ngrok; just need to do SSH forwarding after this).