### PR TITLE
sgf-viewer: Fix prepare_data parsing FAQ section, fix victim/adversary text spacing

### DIFF
--- a/sgf-viewer/prepare_data/prepare_data.py
+++ b/sgf-viewer/prepare_data/prepare_data.py
@@ -43,8 +43,12 @@ if __name__ == "__main__":
 
     for page_path, page in pages.items():
         for section in page["content"]:
-            server = section["server"]
             title = section["title"]
+            if all(key not in section for key in ["paths", "paths_with_line_num"]):
+                print(f"Skipping section {title}: no games")
+                continue
+
+            server = section["server"]
             max_games = section["max_games"]
             games_count = 0
             # Maps destination path to the original index of the source path in

--- a/sgf-viewer/src/components/Section.svelte
+++ b/sgf-viewer/src/components/Section.svelte
@@ -48,6 +48,7 @@
     }
     .annotation-item {
         align-self: flex-start;
+        margin: 0.5vw;
         margin-bottom: 1vh;
     }
     .subheading {


### PR DESCRIPTION
### Fix 1

Add spacing between adversary and victim labels.

Before:
![Screen Shot 2023-06-05 at 18 16 11](https://github.com/AlignmentResearch/KataGoVisualizer/assets/7245938/f8e9cc1b-3911-4c1b-8805-45770617beb8)

After:
![Screen Shot 2023-06-05 at 18 16 31](https://github.com/AlignmentResearch/KataGoVisualizer/assets/7245938/d86496a8-f0f3-45aa-8103-5ea48083e2b9)

### Fix 2

`prepare_data.py` crashes on FAQ section because it expects certain fields for downloading SGFs. The FAQ doesn't have any associated SGFs, though, so `prepare_data.py` just shouldn't do any data preparation for the FAQ section.

The error `prepare_data.py` would hit:
```
Traceback (most recent call last):
  File "prepare_data/prepare_data.py", line 46, in <module>
    server = section["server"]
```
