### PR TITLE
Remove python-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM base AS pipenv
 
 # Install pipenv and compilation dependencies
 RUN pip3 install --user --no-cache-dir pipenv
-RUN apt-get update && apt-get install -y --no-install-recommends gcc python-dev git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends gcc git && rm -rf /var/lib/apt/lists/*
 
 # Tell pipenv to create venv in the current directory
 ENV PIPENV_VENV_IN_PROJECT=1
@@ -30,8 +30,8 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 COPY go_attack_utils ./../go_attack_utils
 COPY streamlit_app/requirements.txt .
-RUN pip3 install -r requirements.txt
-RUN pip3 install tensorflow
+RUN pip3 install --upgrade pip
+RUN pip3 install -r requirements.txt tensorflow --use-pep517
 
 
 FROM base AS streamlit-app


### PR DESCRIPTION
python-dev no longer exists in the latest versions of debian, see e.g. the build failure here https://app.circleci.com/pipelines/github/AlignmentResearch/KataGoVisualizer/653/workflows/c09a6929-e51a-4458-8b5f-eeee32dba983/jobs/1316

I've removed python-dev (which we never needed cause the container comes with python 3.10), and also adjusted the pip install process to work better. Namely, I merged the tensorflow install line with the requirements line. Installing tensorflow separately would also upgrade protobuf to a version that is incompatible with streamlit. The `--use-pep517` is to address https://github.com/pypa/pip/issues/8559.