### PR TITLE
sgf-viewer: Fix behavior of browser back button

### DIFF
--- a/sgf-viewer/src/App.svelte
+++ b/sgf-viewer/src/App.svelte
@@ -21,17 +21,32 @@
     let innerHeight, innerWidth;
     let pagesPaths = Object.keys(pages);
 
-    let windowLocationPathname = window.location.pathname;
-    $: windowLoc = windowLocationPathname.split("/").slice(-1)[0];
+    function getCurrentPath(pagesPaths) {
+        let windowLocationPathname = window.location.pathname;
+        let windowLoc = windowLocationPathname.split("/").slice(-1)[0];
+        return pagesPaths.includes(windowLoc) ? windowLoc : pagesPaths[0];
+    }
 
+    // Ok, here's my mental model of the bug going on.
+    // windowLocationPathname -> windowLoc -> currentPath
+    // Navbar binds and modifies currentPath. That works fine.
+    // But then when popstate happens, windowLocationPathname was never updated
+    // despite changes to currentPath. Then it doesn't propagate changes to
+    // windowLoc or currentPath.
+    //
+    // Fix: get rid of windowlocationpathname, have popstate directly update
+    // current path?
+    //
+    // Hmm. This works better but hash links are still messed up
+
+    let currentPath = getCurrentPath(pagesPaths);
     onMount(() => {
         window.addEventListener(
             "popstate",
-            () => (windowLocationPathname = window.location.pathname)
+            () => (currentPath = getCurrentPath(pagesPaths)),
         );
     });
 
-    $: currentPath = pagesPaths.includes(windowLoc) ? windowLoc : pagesPaths[0];
     $: landingPage = currentPath === "home";
     $: sections = pagesPaths.includes(currentPath)
         ? pages[currentPath]["content"]

--- a/sgf-viewer/src/App.svelte
+++ b/sgf-viewer/src/App.svelte
@@ -10,7 +10,7 @@
     import "@fontsource/lato/900-italic.css";
     import "@fontsource/lato/900.css";
 
-    import { onMount } from "svelte";
+    import { onDestroy, onMount } from "svelte";
     import Citation from "./components/Citation.svelte";
     import NavBar from "./components/NavBar.svelte";
     import Section from "./components/Section.svelte";
@@ -21,31 +21,15 @@
     let innerHeight, innerWidth;
     let pagesPaths = Object.keys(pages);
 
-    function getCurrentPath(pagesPaths) {
+    let currentPath;
+    function updateCurrentPath() {
         let windowLocationPathname = window.location.pathname;
         let windowLoc = windowLocationPathname.split("/").slice(-1)[0];
-        return pagesPaths.includes(windowLoc) ? windowLoc : pagesPaths[0];
+        currentPath = pagesPaths.includes(windowLoc) ? windowLoc : pagesPaths[0];
     }
-
-    // Ok, here's my mental model of the bug going on.
-    // windowLocationPathname -> windowLoc -> currentPath
-    // Navbar binds and modifies currentPath. That works fine.
-    // But then when popstate happens, windowLocationPathname was never updated
-    // despite changes to currentPath. Then it doesn't propagate changes to
-    // windowLoc or currentPath.
-    //
-    // Fix: get rid of windowlocationpathname, have popstate directly update
-    // current path?
-    //
-    // Hmm. This works better but hash links are still messed up
-
-    let currentPath = getCurrentPath(pagesPaths);
-    onMount(() => {
-        window.addEventListener(
-            "popstate",
-            () => (currentPath = getCurrentPath(pagesPaths)),
-        );
-    });
+    updateCurrentPath();
+    onMount(() => window.addEventListener("popstate", updateCurrentPath));
+    onDestroy(() => window.removeEventListener("popstate", updateCurrentPath));
 
     $: landingPage = currentPath === "home";
     $: sections = pagesPaths.includes(currentPath)

--- a/sgf-viewer/src/components/subcomponents/TableOfContents.svelte
+++ b/sgf-viewer/src/components/subcomponents/TableOfContents.svelte
@@ -11,8 +11,6 @@
     $: sections = pagesPaths.includes(currentPath)
         ? pages[currentPath]["content"]
         : [];
-    const rmvUrlParams = () =>
-        window.history.pushState({}, "", window.location.pathname);
 
     // Ternary is just to force Svelte to recompute when currentPath changes
     $: anchors = currentPath ? document.querySelectorAll(".subheading") : [];
@@ -53,7 +51,6 @@
             <a
                 href={"#" +
                     sections.find((sec) => sec.title == jumpTitle).dir_name}
-                on:click={rmvUrlParams}
                 style="flex: 1"
             >
                 Go
@@ -71,7 +68,6 @@
                     >
                         <a
                             href={"#" + section["dir_name"]}
-                            on:click={rmvUrlParams}
                             class={topHeadingIdx == i
                                 ? "curr-section"
                                 : "other-section"}


### PR DESCRIPTION
This PR fixes issues with the browser back button.

## Bug 1: Navbar in Firefox.

Repro: In Firefox (but not in Chrome), go to goattack.far.ai, click on "Baseline Attacks" in the navbar, and click the browser back button. The URL changes, but unexpectedly, the page content does not go back to the home page.

Bug: I'm not sure why this only happens in Firefox, but here's what I think is happening in `App.svelte` to cause this issue:
* We have a variable `let windowLocationPathname = window.location.pathname;` that holds the current page path.
* We have a reactive variable `$: currentPath` that determines the page contents. The variable indirectly depends on windowLocationPathname, so we expect changes in windowLocationPathname to propagate to `currentPath`.
* In `NavBar.svelte`, when we click a link, we modify `currentPath` in order to change the page contents. Clicking the link also does change `window.location.pathname`, but this does NOT update `windowLocationPathname`.
* When we click the browser's back button, we have a `popstate` handler that updates `windowLocationPathname = window.location.pathname`.
* But since `windowLocationPathname` was never updated when we clicked a NavBar link, the value of `windowLocationPathname` is the same before and after the `popstate` handler. Then no changes are propagated to `currentPath`.

Fix: Make the `popstate` handler directly update `currentPath`.

Other fixes I considered:
* Making `windowLocationPathname` reactive (`$: windowLocationPathname = window.location.pathname;`) doesn't work
* SvelteKit has an import `import { page } from '$app/stores';`, and then you can get the current URL with `$page.url.pathname`. But SvelteKit is a framework based on Svelte, not a drop-in library interoperates with existing Svelte apps. It might not be easy to convert our existing webapp to SvelteKit.
* `svelte-router` has a hook `useLocation()` that gets the current path, but in `App.svelte` it just returns `undefined`. I think it only tracks the location within `svelte-router` `<Router>` components?

Maybe there's an cleaner fix, I'm not familiar with Svelte

## Bug 2: Table of contents (ToC)

Repro: Go to goattack.far.ai/transfer and alternately click on the two ToC entries a bunch of times to navigate between URL fragments `#leela` and `#elf`. Now click the URL back button a few times. The expected browser history is `[transfer#leela, transfer#elf, transfer#leela, transfer#elf, ...]`. But instead the history is `[transfer#leela, transfer, transfer#elf, transfer, transfer#leela, transfer, transfer#elf, ...]`

Fix: Just get rid of the `onClick` handler in the ToC that modifies the history with `window.history.pushState()`. I'm not sure why that `onClick` handler existed.

## Testing

Tested the PR on Firefox and Chrome