### PR TITLE
GoBoard: Fix responsiveness

### DIFF
--- a/sgf-viewer/src/components/subcomponents/GoBoard.svelte
+++ b/sgf-viewer/src/components/subcomponents/GoBoard.svelte
@@ -8,6 +8,8 @@
     export let sgfPath: string;
 
     let goBoardDiv: HTMLElement;
+    let wgoPlayer: WGo.BasicPlayer;
+    const LAST_MOVE_NUM = 10000;
 
     function releaseCanvas(canvas) {
         canvas.width = 1;
@@ -16,14 +18,12 @@
         ctx && ctx.clearRect(0, 0, 1, 1);
     }
 
-    $: if (goBoardDiv) {
+    $: if (goBoardDiv && !wgoPlayer) {
         [...goBoardDiv.getElementsByTagName("CANVAS")].forEach(releaseCanvas);
 
-        let wgoPlayer = new (<any>window).WGo.BasicPlayer(goBoardDiv, {
-            sgfFile: sgfPath,
+        wgoPlayer = new (<any>window).WGo.BasicPlayer(goBoardDiv, {
             layout: (<any>window).WGo.BasicPlayer.dynamicLayout,
             allowIllegalMoves: true,
-            move: 9999,
             enableWheel: false,
             board: {
                 // Options: NORMAL, PAINTED, REALISTIC, GLOW, SHELL, MONO, CR, LB, SQ, TR, MA, SL, SM, outline, mini
@@ -32,6 +32,9 @@
             },
         });
         wgoPlayers[dirName] = wgoPlayer;
+    }
+    $: if (wgoPlayer && sgfPath) {
+      wgoPlayer.loadSgfFromFile(sgfPath, LAST_MOVE_NUM);
     }
 </script>
 

--- a/sgf-viewer/src/components/subcomponents/GoBoard.svelte
+++ b/sgf-viewer/src/components/subcomponents/GoBoard.svelte
@@ -9,6 +9,8 @@
 
     let goBoardDiv: HTMLElement;
     let wgoPlayer: WGo.BasicPlayer;
+    // Arbitrary large number, needs to be larger than the move count in any of
+    // our SGFs.
     const LAST_MOVE_NUM = 10000;
 
     function releaseCanvas(canvas) {


### PR DESCRIPTION
## Bug

fixes #105 

### Description

On the Go attack website, the Go board is resized too small and not centered when we shrink from a large window width to a small width.

### Diagnosis

The Go player's CSS class is supposed to change as the window is resized. However, old CSS classes are not being removed as expected. In particular, if the window is large and shrinks, the CSS class should change from `wgo-twocols wgo-large` to, say, `wgo-medium`. Instead, the CSS class is `wgo-twocols wgo-large wgo-medium`, and the unexpected remaining `wgo-twocols` class is causing the incorrect Go board appearance.

Why does this happen? In GoBoard.svelte, we create a Go player object `wgoPlayer` and give it a div to attach to. In fact we're creating `wgoPlayer` responsively — we create a new `wgoPlayer` whenever the selected SGF changes. Each `wgoPlayer` is attached to the same div, and there's no way to destroy the old `wgoPlayer`. We then actually create two `wgoPlayer`s upon page load, one when the selected SGF is `undefined` and one when the selected SGF is the first row in the game list. These two `wgoPlayer`s both append to the CSS class and cause the CSS class to not be the expected value. (Similarly, each time we select a different SGF from the game list, another `wgoPlayer` is created, and the CSS class becomes longer and longer.)

## Fix

* Only create `wgoPlayer` once in `GoBoard.svelte`
* Load new SGFs using the existing `wgoPlayer`

## Testing

* Go board size looks correct on window resize
* Check for obvious regressions
  * Clicking on a different game in the game list still works
  * Clicking on a move number link in the "Game analysis" tab still works 