### PR TITLE
sgf-viewer: Fix ToC anchor regression

### DIFF
--- a/sgf-viewer/src/App.svelte
+++ b/sgf-viewer/src/App.svelte
@@ -44,10 +44,8 @@
     <div class="content">
         <Title showAuthors={landingPage} />
         <main>
-            <!-- Empty anchor target. Named for link backwards compatibility. -->
-            <div id="contents" />
             {#key currentPath}
-                <h2>{pages[currentPath]["title"]}</h2>
+                <h2 id="contents">{pages[currentPath]["title"]}</h2>
                 {#if pages[currentPath]["description"]}
                     {#each pages[currentPath]["description"] as description}
                         <p class="description-p">{@html description}</p>

--- a/sgf-viewer/src/components/Section.svelte
+++ b/sgf-viewer/src/components/Section.svelte
@@ -6,42 +6,40 @@
     let sgfPath: string;
 </script>
 
-<div class="centerflex" id={section["dir_name"]}>
-    <h3>
-        {section["title"]}
-    </h3>
-    <div class="text-wrapper">
-        {#each section["description"] as description}
-            <p>{@html description}</p>
-        {/each}
-    </div>
-    {#if section["paths"] || section["paths_with_line_num"]}
-        <div style="max-width: 100%;">
-            <GameList dirName={section["dir_name"]} bind:sgfPath />
-            <div class="board-wrapper">
-                <GoBoard dirName={section["dir_name"]} {sgfPath} />
-            </div>
-        </div>
-        <div class="d-flex m-2">
-            <p class="me-auto m-2">
-                <b>Victim:</b>
-                {@html section["victim"]}
-            </p>
-            <p class="m-2 text-end">
-                <b>Adversary:</b>
-                {@html section["adversary"]}
-            </p>
-        </div>
-    {/if}
-    {#if section["figure"]}
-        <div class="iframe-container">
-            <iframe src="{section["figure"]}" title={section["title"]}></iframe>
-        </div>
-    {/if}
-    {#if section["discussion"]}
-        <p>{section["discussion"]}</p>
-    {/if}
+<h3 id={section["dir_name"]}>
+    {section["title"]}
+</h3>
+<div class="text-wrapper">
+    {#each section["description"] as description}
+        <p>{@html description}</p>
+    {/each}
 </div>
+{#if section["paths"] || section["paths_with_line_num"]}
+    <div style="max-width: 100%;">
+        <GameList dirName={section["dir_name"]} bind:sgfPath />
+        <div class="board-wrapper">
+            <GoBoard dirName={section["dir_name"]} {sgfPath} />
+        </div>
+    </div>
+    <div class="d-flex m-2">
+        <p class="me-auto m-2">
+            <b>Victim:</b>
+            {@html section["victim"]}
+        </p>
+        <p class="m-2 text-end">
+            <b>Adversary:</b>
+            {@html section["adversary"]}
+        </p>
+    </div>
+{/if}
+{#if section["figure"]}
+    <div class="iframe-container">
+        <iframe src="{section["figure"]}" title={section["title"]}></iframe>
+    </div>
+{/if}
+{#if section["discussion"]}
+    <p>{section["discussion"]}</p>
+{/if}
 
 <style>
     .iframe-container {


### PR DESCRIPTION
Fixes #108 

Bug: Clicking on an entry in the table of contents should update the the URL to the anchor associated with that entry, but #103 introduced a new external table-of-contents library that no longer does this.

Fix: The table-of-contents library actually handles this automatically if the anchor is placed on the `<h{1..6}>` tag (from which the table of contents is generated), so I've moved the anchors from `<div>`s onto `<h{1..6}>`s.