### PR TITLE
sgf-viewer: Toggle visibility of game list

### DIFF
--- a/sgf-viewer/src/components/subcomponents/GameList.svelte
+++ b/sgf-viewer/src/components/subcomponents/GameList.svelte
@@ -36,6 +36,7 @@
         }
         games = games; // trigger Svelte reactivity. See https://svelte.dev/tutorial/updating-arrays-and-objects
     }
+    $: gamesAreCollapsible = games.length > 1;
 
     fetch(`/sgfs/${dirName}/game_infos.csv`)
         .then((r) => r.text())
@@ -57,45 +58,57 @@
     }
 </script>
 
-<div class="table-responsive">
-    <table class="table table-hover">
-        <thead>
-            <tr>
-                <!-- slice(0, -1) drops the sgf_path column -->
-                {#each Object.values(tableColumns).slice(0, -1) as header}
-                    <th scope="col">{header}</th>
-                {/each}
-                <th scope="col">Download</th>
-            </tr>
-        </thead>
-        <tbody>
-            {#each games as game, index (index)}
-                <tr
-                    class:table-active={index === selectedRow}
-                    on:click={() => clickCell(index)}
-                >
-                    {#each game.slice(0, -1) as cell}
-                        <td>{cell}</td>
+{#if gamesAreCollapsible}
+    <p class="text-center">
+        <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
+          data-bs-target="#{dirName}-game-list" aria-expanded="true" aria-controls="{dirName}-game-list">
+            <span class="if-collapsed">Show</span>
+            <span class="if-expanded">Hide</span>
+            game list
+        </button>
+    </p>
+{/if}
+<div class:collapse={gamesAreCollapsible} id="{dirName}-game-list">
+    <div class="table-responsive">
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <!-- slice(0, -1) drops the sgf_path column -->
+                    {#each Object.values(tableColumns).slice(0, -1) as header}
+                        <th scope="col">{header}</th>
                     {/each}
-                    <td>
-                        <a
-                            href={indexToSgfPath(index)}
-                            download={"go_game.sgf"}
-                        >
-                            <div class="icon">
-                                <MdFileDownload />
-                            </div>
-                        </a>
-                    </td>
+                    <th scope="col">Download</th>
                 </tr>
-            {/each}
-        </tbody>
-    </table>
+            </thead>
+            <tbody>
+                {#each games as game, index (index)}
+                    <tr
+                        class:table-active={index === selectedRow}
+                        on:click={() => clickCell(index)}
+                    >
+                        {#each game.slice(0, -1) as cell}
+                            <td>{cell}</td>
+                        {/each}
+                        <td>
+                            <a
+                                href={indexToSgfPath(index)}
+                                download={"go_game.sgf"}
+                            >
+                                <div class="icon">
+                                    <MdFileDownload />
+                                </div>
+                            </a>
+                        </td>
+                    </tr>
+                {/each}
+            </tbody>
+        </table>
+    </div>
 </div>
 
 <style>
-    th,
-    td {
+
+    th, td {
         text-align: center;
         font-weight: bold;
         padding: 8px;

--- a/sgf-viewer/src/components/subcomponents/GameList.svelte
+++ b/sgf-viewer/src/components/subcomponents/GameList.svelte
@@ -4,6 +4,8 @@
     export let dirName: string;
     export let sgfPath: string = "";
 
+    $: gameListId = `${dirName}_game_list`;
+
     let selectedRow: number = 0;
     let games: Array<Array<string>> = [];
     const tableColumns = {
@@ -60,15 +62,14 @@
 
 {#if gamesAreCollapsible}
     <p class="text-center">
-        <button class="btn btn-primary" type="button" data-bs-toggle="collapse"
-          data-bs-target="#{dirName}-game-list" aria-expanded="true" aria-controls="{dirName}-game-list">
+        <button class="btn btn-primary" type="button" data-bs-toggle="collapse" data-bs-target="#{gameListId}" aria-expanded="false" aria-controls={gameListId}>
             <span class="if-collapsed">Show</span>
             <span class="if-expanded">Hide</span>
             game list
         </button>
     </p>
 {/if}
-<div class:collapse={gamesAreCollapsible} id="{dirName}-game-list">
+<div class:collapse={gamesAreCollapsible} id={gameListId}>
     <div class="table-responsive">
         <table class="table table-hover">
             <thead>
@@ -107,7 +108,6 @@
 </div>
 
 <style>
-
     th, td {
         text-align: center;
         font-weight: bold;

--- a/sgf-viewer/src/css/app.css
+++ b/sgf-viewer/src/css/app.css
@@ -76,7 +76,7 @@ h1, h2, h3, h4, h5, h6 {
  * dynamically modified attributes
  * (https://github.com/sveltejs/svelte/issues/5804).
  */
-.btn [aria-expanded="false"] > .if-expanded,
-.btn [aria-expanded="true"] > .if-collapsed {
+.btn[aria-expanded="false"] > .if-expanded,
+.btn[aria-expanded="true"] > .if-collapsed {
   display: none;
 }

--- a/sgf-viewer/src/css/app.css
+++ b/sgf-viewer/src/css/app.css
@@ -13,7 +13,6 @@
 
   --bs-body-bg: var(--near-white);
   --bs-body-bg-rgb: 247, 247, 247;
-
 }
 
 html {
@@ -56,4 +55,28 @@ a:hover {
 h1, h2, h3, h4, h5, h6 {
   /* Add additional margin to the scroll location of a table-of-contents link. */
   scroll-margin-top: 1em;
+}
+
+.btn {
+  --bs-btn-bg: var(--medium-accent-color);
+  --bs-btn-border-color: var(--medium-accent-color);
+  --bs-btn-hover-bg: var(--logo-color);
+  --bs-btn-hover-border-color: var(--logo-color);
+  --bs-btn-active-bg: var(--medium-accent-color);
+  --bs-btn-active-border-color: var(--medium-accent-color);
+  --bs-btn-focus-shadow-rgb: 34, 102, 102;
+}
+
+/* CSS rule for displaying different content in a Bootstrap button
+ * controlling collapsible content, as clicking the button toggles its
+ * aria-expanded attribute.
+ * We define this in a global .css file because otherwise if defined locally in
+ * a .svelte file, Svelte would optimize out one of selectors due to no matching
+ * elements appearing in the file, as Svelte does not have awareness of
+ * dynamically modified attributes
+ * (https://github.com/sveltejs/svelte/issues/5804).
+ */
+.btn [aria-expanded="false"] > .if-expanded,
+.btn [aria-expanded="true"] > .if-collapsed {
+  display: none;
 }

--- a/sgf-viewer/src/css/bootstrap.scss
+++ b/sgf-viewer/src/css/bootstrap.scss
@@ -20,6 +20,7 @@
 @import "../node_modules/bootstrap/scss/root";
 
 // 6. Optionally include any other parts as needed
+@import "../node_modules/bootstrap/scss/buttons";
 @import "../node_modules/bootstrap/scss/containers";
 @import "../node_modules/bootstrap/scss/dropdown";
 @import "../node_modules/bootstrap/scss/grid";


### PR DESCRIPTION
Issue: We have links jumping between moves in a Go game, but if there's a long list of games then the Go board is easily off the screen and it's not obvious to the user that clicking the links is actually doing anything

fix: Adds button for toggling visibility of each list of Go games