### PR TITLE
sgf-viewer: Fix navbar flicker

### DIFF
--- a/sgf-viewer/src/components/NavBar.svelte
+++ b/sgf-viewer/src/components/NavBar.svelte
@@ -15,10 +15,16 @@
     // modifications to make it work with Svelte's dynamic element rendering.
     // (The other solution using HTML attributes given in the SO answer, though
     // it's simpler, breaks the links' actual href functionality.)
-    $: navLinks = navbarSupportedContent?.querySelectorAll('.nav-item:not(.dropdown)');
+    $: navLinks = navbarSupportedContent?.querySelectorAll(".nav-item:not(.dropdown)");
     $: bootstrapCollapse = navbarSupportedContent ? Collapse.getOrCreateInstance(navbarSupportedContent, {toggle: false}) : undefined;
     $: navLinks?.forEach((link) => {
-           link.addEventListener('click', () => { bootstrapCollapse.toggle() });
+           link.addEventListener("click", () => {
+               // Checking for "show" class ensures this only runs on mobile, not
+               // desktop.
+               if (navbarSupportedContent.classList.contains("show")) {
+                   bootstrapCollapse.toggle()
+               }
+           });
     })
 </script>
 


### PR DESCRIPTION
Bug behavior:
* Clicking a link in the navbar on desktop causes it to flicker

Bug diagnosis:
* We have some custom JS I copied from StackOverflow for collapsing the navbar on mobile when clicking a link. The JS fires on desktop as well and tries to collapse the desktop navbar, causing the flicker

Fix:
* Add a guard around the navbar collapse JS, only firing it if the navbar is mobile. I'm also going to make an edit to the StackOverflow answer