### PR TITLE
website: Display warning if no JavaScript

### DIFF
--- a/sgf-viewer/index.html
+++ b/sgf-viewer/index.html
@@ -23,6 +23,9 @@
 </head>
 
 <body>
+  <noscript>
+    <p>JavaScript is required to view this website.</p>
+  </noscript>
   <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>


### PR DESCRIPTION
Website is blank if no javascript since all page content is loaded dynamically with javascript.
This PR adds a warning message if javascript is not enabled