### PR TITLE
website: Update svelte-toc and remove table-of-contents mount delay

### DIFF
--- a/sgf-viewer/package-lock.json
+++ b/sgf-viewer/package-lock.json
@@ -20,7 +20,7 @@
         "svelte": "^3.49.0",
         "svelte-check": "^2.8.1",
         "svelte-preprocess": "^4.10.7",
-        "svelte-toc": "^0.5.8",
+        "svelte-toc": "^0.5.9",
         "tslib": "^2.4.0",
         "typescript": "^4.6.4",
         "vite": "^3.1.0"
@@ -1761,12 +1761,12 @@
       }
     },
     "node_modules/svelte-toc": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/svelte-toc/-/svelte-toc-0.5.8.tgz",
-      "integrity": "sha512-WU7Rh9CSmtCllCT9btRsoBeFsNBNLdAdymUGks6gKT7ByQ/bRMiX8/SQ/MbphgYZjeXjEdv1FpeLNU6sqWFiDw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/svelte-toc/-/svelte-toc-0.5.9.tgz",
+      "integrity": "sha512-upnWdUWBhwjagRJ6/UQYAETUALsH3kfVTA3tyiCSKuGqMc5mckI1dqe2Rkg8SyatU0fqtd/f6X5VCd8829H9Tg==",
       "dev": true,
       "dependencies": {
-        "svelte": "^4.2.12"
+        "svelte": "^4.2.18"
       }
     },
     "node_modules/svelte-toc/node_modules/estree-walker": {
@@ -1788,9 +1788,9 @@
       }
     },
     "node_modules/svelte-toc/node_modules/svelte": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
-      "integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
+      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
@@ -3035,12 +3035,12 @@
       }
     },
     "svelte-toc": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/svelte-toc/-/svelte-toc-0.5.8.tgz",
-      "integrity": "sha512-WU7Rh9CSmtCllCT9btRsoBeFsNBNLdAdymUGks6gKT7ByQ/bRMiX8/SQ/MbphgYZjeXjEdv1FpeLNU6sqWFiDw==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/svelte-toc/-/svelte-toc-0.5.9.tgz",
+      "integrity": "sha512-upnWdUWBhwjagRJ6/UQYAETUALsH3kfVTA3tyiCSKuGqMc5mckI1dqe2Rkg8SyatU0fqtd/f6X5VCd8829H9Tg==",
       "dev": true,
       "requires": {
-        "svelte": "^4.2.12"
+        "svelte": "^4.2.18"
       },
       "dependencies": {
         "estree-walker": {
@@ -3062,9 +3062,9 @@
           }
         },
         "svelte": {
-          "version": "4.2.17",
-          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
-          "integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
+          "version": "4.2.18",
+          "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
+          "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
           "dev": true,
           "requires": {
             "@ampproject/remapping": "^2.2.1",

--- a/sgf-viewer/package.json
+++ b/sgf-viewer/package.json
@@ -17,7 +17,7 @@
     "svelte": "^3.49.0",
     "svelte-check": "^2.8.1",
     "svelte-preprocess": "^4.10.7",
-    "svelte-toc": "^0.5.8",
+    "svelte-toc": "^0.5.9",
     "tslib": "^2.4.0",
     "typescript": "^4.6.4",
     "vite": "^3.1.0"

--- a/sgf-viewer/src/App.svelte
+++ b/sgf-viewer/src/App.svelte
@@ -38,16 +38,6 @@
         ? pages[currentPath]["content"]
         : [];
     $: summary = pages[currentPath]["summary"]
-
-    // Hack: The ToC interferes with scrolling to anchors on page load:
-    // https://github.com/janosh/svelte-toc/issues/57
-    // Delaying mounting the ToC is our current workaround.
-    // On my (tomtseng's) machine, we need a timeout of ~220ms to avoid the
-    // issue.
-    let mountToc: boolean = false;
-    onMount(() => {
-        setTimeout(() => mountToc = true, 700);
-    });
 </script>
 
 <svelte:head>
@@ -75,29 +65,24 @@
     </div>
     <!-- Give the table of contents the same breakpoint as the navbar and give
       it a fixed width. -->
-    {#if mountToc}
-        <Toc
-            titleTag="h5"
-            breakpoint={bootstrapLargeBreakpoint}
-            --toc-min-width="12em"
-            --toc-desktop-max-width="12em"
-            --toc-mobile-btn-bg="rgba(var(--bs-light-rgb), 0.8)"
-            --toc-mobile-bg="rgba(var(--bs-light-rgb), 1)"
-            --toc-active-color="var(--near-white)"
-            --toc-active-bg="var(--medium-accent-color)"
-        >
-            <div class="toc-icon" slot="open-toc-icon">
-                <!-- The default mobile icon looks too much like the navbar icon.
-                  We copy Wikipedia in using the standard hamburger icon for the
-                  navbar and a bullet list icon for the table of contents
-                -->
-                <MdFormatListBulleted />
-            </div>
-        </Toc>
-    {:else}
-        <!-- Placeholder for the ToC to avoid layout shift. -->
-        <div class="toc-placeholder"></div>
-    {/if}
+    <Toc
+        titleTag="h5"
+        breakpoint={bootstrapLargeBreakpoint}
+        --toc-min-width="12em"
+        --toc-desktop-max-width="12em"
+        --toc-mobile-btn-bg="rgba(var(--bs-light-rgb), 0.8)"
+        --toc-mobile-bg="rgba(var(--bs-light-rgb), 1)"
+        --toc-active-color="var(--near-white)"
+        --toc-active-bg="var(--medium-accent-color)"
+    >
+        <div class="toc-icon" slot="open-toc-icon">
+            <!-- The default mobile icon looks too much like the navbar icon.
+              We copy Wikipedia in using the standard hamburger icon for the
+              navbar and a bullet list icon for the table of contents
+            -->
+            <MdFormatListBulleted />
+        </div>
+    </Toc>
 </div>
 
 <style>
@@ -122,12 +107,6 @@
     .toc-icon {
         height: 1em;
         width: 1em;
-    }
-    @media (min-width: 992px) {  /* 992 === bootstrapLargeBreakpoint  */
-        .toc-placeholder {
-            min-width: 12em;
-            width: 12em;
-        }
     }
     #contents {
         /* Extra scroll margin when navigating to the #contents anchor. */


### PR DESCRIPTION
In PR #123 I added a delay to mounting the table of contents due to a Chrome bug interacting with svelte-toc, but the developer of svelte-toc has since added a workaround to the bug (https://github.com/janosh/svelte-toc/issues/57).

This PR updates svelte-toc and hence can remove the delay.