### PR TITLE
circleci: Update soon-to-be-deprecated image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ commands:
           key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjgh
       - run:
           command: |
-            apt update
-            DEBIAN_FRONTEND=noninteractive apt install python3.10-venv
+            sudo apt update
+            DEBIAN_FRONTEND=noninteractive sudo apt install python3.10-venv
             python3.10 -m venv venv
             . venv/bin/activate
             pip install -r .circleci/requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}
+          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjg
       - run:
           command: |
             python3.10 -m venv venv
             . venv/bin/activate
             pip install -r .circleci/requirements.txt
       - save_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}
+          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjg
           paths:
             - "venv"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjgh
+          key: v1-deps-{{ checksum ".circleci/requirements.txt" }}
       - run:
           command: |
             sudo apt update
@@ -23,7 +23,7 @@ commands:
             pip install -r .circleci/requirements.txt
 
       - save_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjgh
+          key: v1-deps-{{ checksum ".circleci/requirements.txt" }}
           paths:
             - "venv"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}-v1
+          key: deps-{{ checksum ".circleci/requirements.txt" }}
       - run:
           command: |
-            python3 -m venv venv
+            python3.10 -m venv venv
             . venv/bin/activate
             pip install -r .circleci/requirements.txt
       - save_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}-v1
+          key: deps-{{ checksum ".circleci/requirements.txt" }}
           paths:
             - "venv"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}
+          key: deps-{{ checksum ".circleci/requirements.txt" }}-v1
       - run:
           command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install -r .circleci/requirements.txt
       - save_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}
+          key: deps-{{ checksum ".circleci/requirements.txt" }}-v1
           paths:
             - "venv"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executors:
     machine:
       # https://discuss.circleci.com/t/linux-machine-executor-update-2022-july-q3-update/44873
       # This image contains Chrome (and seemingly chromedriver), Docker Compose and Python
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2024.05.1
       docker_layer_caching: true
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,17 @@ commands:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjg
+          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjgh
       - run:
           command: |
+            apt update
+            DEBIAN_FRONTEND=noninteractive apt install python3.10-venv
             python3.10 -m venv venv
             . venv/bin/activate
             pip install -r .circleci/requirements.txt
+
       - save_cache:
-          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjg
+          key: deps-{{ checksum ".circleci/requirements.txt" }}-asjdgklasjdgklasjgh
           paths:
             - "venv"
 


### PR DESCRIPTION
The Ubuntu image we're using for CI [will be deprecated](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177) at the end of this month. This PR updates the image.

A few changes in setting up the venv:
* Call `python3.10` instead of `python3`, because in this new image, `python3` is version 3.12 rather than 3.10. Using 3.12 causes [a bunch of flake8 errors](https://app.circleci.com/pipelines/github/AlignmentResearch/KataGoVisualizer/1039/workflows/515d0768-9eea-4821-8a05-6b688c15f72a/jobs/2091). Most of them actually just look like a [flake8 bug](https://stackoverflow.com/questions/77401175/how-to-make-flake8-ignore-syntax-within-strings). Some others are complaining about us not using raw strings for regex matching since python3.12 is more strict about escape sequences like `\d` appearing in strings.
* `apt-get install python3.10-venv` because otherwise the `python3.10 -m venv venv` command complains
* [Prefix cache key with `v1`](https://circleci.com/docs/caching/#clearing-cache) because the old cache doesn't work (the venv in the old cache symlinks to python 3.10.5, but that doesn't exist in the new image because it has version 3.10.12 instead). 